### PR TITLE
Close file descriptors before executing the sub-processes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.2.1)
+    activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-      zeitwerk (~> 2.2)
+      zeitwerk (~> 2.2, >= 2.2.2)
     backports (3.17.0)
     byebug (11.1.1)
     coderay (1.1.2)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.7)
     diff-lcs (1.3)
     fakefs (1.0.0)
     faraday (1.0.0)
@@ -18,22 +18,22 @@ GEM
     figaro (1.1.1)
       thor (~> 0.14)
     hashie (4.1.0)
-    i18n (1.8.2)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     method_source (0.9.2)
-    minitest (5.14.0)
+    minitest (5.14.2)
     multi_json (1.14.1)
     multipart-post (2.1.1)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    nio4r (2.5.2)
+    nio4r (2.5.4)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     pry-byebug (3.8.0)
       byebug (~> 11.0)
       pry (~> 0.10)
-    puma (4.3.3)
+    puma (4.3.6)
       nio4r (~> 2.0)
     rack (2.2.2)
     rack-protection (2.0.8.1)
@@ -76,9 +76,9 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tzinfo (1.2.6)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    zeitwerk (2.3.0)
+    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby
@@ -102,4 +102,4 @@ DEPENDENCIES
   sinatra-namespace
 
 BUNDLED WITH
-   1.17.3
+   2.1.4

--- a/libexec/execute-as-user.rb
+++ b/libexec/execute-as-user.rb
@@ -27,6 +27,8 @@
 # https://github.com/openflighthpc/flight-desktop-restapi
 #===============================================================================
 
+require 'etc'
+
 begin
   # Extracts the user and command from the ruby ARGV
   user = ARGV.first

--- a/libexec/execute-as-user.rb
+++ b/libexec/execute-as-user.rb
@@ -49,7 +49,7 @@ begin
   }
 
   # Executes the command
-  exec(env, *argv, unsetenv_others: true)
+  exec(env, *argv, unsetenv_others: true, close_others: true)
 rescue => e
   # Print any ruby errors to STDERR
   $stderr.puts e.message


### PR DESCRIPTION
This prevents the sub-processes from holding onto puma's port

Also updated `rack`, `puma`, and `activesupport` as recommended by dependabot. Finally I have updated the gemfile bundler to `2.1.4`. 

For some reason I was having issues with `Etc` not being found. Not sure if this is a ruby/ bundler version issue or some other change. However its a quick fix to `require etc` when needed