### PR TITLE
Webify the desktop sessions when required

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /var
 /log
 /vendor
+etc/*.local.yaml
 etc/shared-secret.conf
 
 # NOTE: This is a general ignore all yaml files in the config directory

--- a/app/models.rb
+++ b/app/models.rb
@@ -66,21 +66,6 @@ class Session < Hashie::Trash
     sessions.find { |s| s.id == id }
   end
 
-  # NOTE: The flight desktop command generates a UUID for each session, however
-  # it also allows accepts shortened versions. This means their is some "fuzziness"
-  # in the ID.
-  #
-  # Revists as necessary, we may want to disable this
-  #
-  # NOTE: GOTCHA
-  # This method does not return the websockify port. It is being maintained for
-  # prosperity
-  def self.find_by_fuzzy_id(fuzzy_id, user:)
-    cmd = SystemCommand.find_session(fuzzy_id, user: user)
-    return nil unless cmd.code == 0
-    build_from_output(cmd.stdout, user: user)
-  end
-
   def self.build_from_output(lines, user:)
     lines = lines.split("\n") if lines.is_a?(String)
     data = lines.each_with_object({}) do |line, memo|

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -134,6 +134,10 @@ class SystemCommand < Hashie::Dash
     Builder.new("#{FlightDesktopRestAPI.config.desktop_command} start").call(desktop, user: user)
   end
 
+  def self.webify_session(id, user:)
+    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} webify").call(id, user: user)
+  end
+
   def self.kill_session(id, user:)
     Builder.new("#{FlightDesktopRestAPI.config.desktop_command} kill").call(id, user: user)
   end

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -26,16 +26,16 @@
 #===============================================================================
 
 # =============================================================================
-# Pam Configuration Name [DEFAULT]
+# Bind Address
 # Specify which pam configuration file should be used to authenticate requests.
 # It should correlate to a filename stored within /etc/pam.d
 #
-# The environment variable flight_DESKTOP_RESTAPI_pam_conf takes precedence.
+# The environment variable flight_DESKTOP_RESTAPI_bind_address takes precedence.
 # =============================================================================
-# pam_conf:
+# bind_address: tcp://127.0.0.1:915
 
 # =============================================================================
-# CORS Domain [OPTIONAL]
+# CORS Domain
 # Enable cross origin resource sharing from the given domain. CORS is disabled
 # by default
 #
@@ -50,13 +50,44 @@
 #
 # The environment variable flight_DESKTOP_RESTAPI_refresh_rate takes precedence.
 # =============================================================================
-# refresh_rate:
+# refresh_rate: 3600
 
 # =============================================================================
-# Log Level [DEFAULT]
+# Desktop Command
+#
+# The prefix used to run the flight-desktop command line utility
+#
+# The environment variable flight_DESKTOP_RESTAPI_desktop_command takes
+# precedence.
+# =============================================================================
+# desktop_command: flight desktop
+
+# =============================================================================
+# Shared Secret Path
+# The path to the file containing the shared secret used to verify the login
+# credentials.
+#
+# The environment variable flight_DESKTOP_RESTAPI_shared_secret_path takes
+# precedence.
+#
+# Relative paths are expanded from the installation directory.
+# =============================================================================
+# shared_secret_path: etc/shared-secret.conf
+
+# =============================================================================
+# SSO Cookie Domain
+# The name of cookie used to store the login credentials
+#
+# The environment variable flight_DESKTOP_RESTAPI_sso_cookie_domain takes
+# precedence.
+# =============================================================================
+# sso_cookie_name: flight_login
+
+# =============================================================================
+# Log Level
 # Specify which level of logging should be used. The supported values are:
 # fatal, error, warn, info, or debug
 #
 # The environment variable flight_DESKTOP_RESTAPI_log_level takes precedence.
 # =============================================================================
-# log_level:
+# log_level: info


### PR DESCRIPTION
If a session was started before `python-websockify` was installed, it will not have the required web infrastructure in order to connect to it.

When the restapi loads one of these sessions, it will attempt to start the infrastructure before continuing.

---

Also updated the config