### PR TITLE
Frequently check for available desktops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 /var
 /log
 /vendor
+etc/*.local.yaml
 etc/shared-secret.conf
 
 # NOTE: This is a general ignore all yaml files in the config directory

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ source "https://rubygems.org"
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activesupport', require: 'active_support/all'
+gem 'concurrent-ruby'
 gem 'flight_auth', github: "openflighthpc/flight_auth", branch: "297cb7241b820d334e5d593c4e237a81b83a9995"
 gem 'flight_configuration', github: 'openflighthpc/flight_configuration', branch: '24928260e542768f13cc513a3a08af69f690dfbc'
 gem 'hashie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport
+  concurrent-ruby
   fakefs
   flight_auth!
   flight_configuration!

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -143,7 +143,7 @@ class SystemCommand < Hashie::Dash
   end
 
   def self.verify_desktop(desktop, user:)
-    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} verify").call(desktop, user: user)
+    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} verify --force").call(desktop, user: user)
   end
 
   def self.avail_desktops(user:)

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -51,7 +51,8 @@ Concurrent::TimerTask.new(**opts) do |task|
                         .each_line.map do |line|
     data = line.split("\t")
     home = data[2].empty? ? nil : data[2]
-    Desktop.new(name: data[0], summary: data[1], homepage: home)
+    verified = data[3] == 'Verified'
+    Desktop.new(name: data[0], summary: data[1], homepage: home, verified: verified)
   end
 
   models.each { |m| m.verify_desktop(user: ENV['USER']) } if count == 0

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -51,7 +51,7 @@ Concurrent::TimerTask.new(**opts) do |task|
                         .each_line.map do |line|
     data = line.split("\t")
     home = data[2].empty? ? nil : data[2]
-    verified = data[3] == 'Verified'
+    verified = (data[3].chomp == 'Verified')
     Desktop.new(name: data[0], summary: data[1], homepage: home, verified: verified)
   end
 

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -55,10 +55,17 @@ Concurrent::TimerTask.new(**opts) do |task|
     Desktop.new(name: data[0], summary: data[1], homepage: home, verified: verified)
   end
 
-  models.each { |m| m.verify_desktop(user: ENV['USER']) } if count == 0
+  # Set the initial state of the desktops
   hash = models.map { |m| [m.name, m] }.to_h
-
   Desktop.instance_variable_set(:@cache, hash)
+
+  # Preform the additional verification step (when required)
+  if count == 0
+    models.each { |m| m.verify_desktop(user: ENV['USER']) }
+    hash = models.map { |m| [m.name, m] }.to_h
+    Desktop.instance_variable_set(:@cache, hash)
+  end
+
   DEFAULT_LOGGER.info "Finished #{'re' unless first}loading the desktops"
   first = false
   count = (count + 1) % verify_interval

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -31,26 +31,19 @@
 return if ENV['RACK_ENV'] == 'test'
 
 # Periodically reload and verify the desktops
-Thread.new do
-  count = 0
-  loop do
-    models = SystemCommand.avail_desktops(user: ENV['USER'])
-                          .tap(&:raise_unless_successful)
-                          .stdout
-                          .each_line.map do |line|
-      data = line.split("\t")
-      home = data[2].empty? ? nil : data[2]
-      Desktop.new(name: data[0], summary: data[1], homepage: home)
-    end
-
-    models.each { |m| m.verify_desktop(user: ENV['USER']) }
-    hash = models.map { |m| [m.name, m] }.to_h
-
-    Desktop.instance_variable_set(:@cache, hash)
-    DEFAULT_LOGGER.info "Finished #{'re' if count > 0 }loading the desktops"
-    count += 1
-
-    sleep FlightDesktopRestAPI.config.refresh_rate
+Concurrent::TimerTask.new(execution_interval: FlightDesktopRestAPI.config.refresh_rate, run_now: true) do
+  models = SystemCommand.avail_desktops(user: ENV['USER'])
+                        .tap(&:raise_unless_successful)
+                        .stdout
+                        .each_line.map do |line|
+    data = line.split("\t")
+    home = data[2].empty? ? nil : data[2]
+    Desktop.new(name: data[0], summary: data[1], homepage: home)
   end
-end
 
+  models.each { |m| m.verify_desktop(user: ENV['USER']) }
+  hash = models.map { |m| [m.name, m] }.to_h
+
+  Desktop.instance_variable_set(:@cache, hash)
+  DEFAULT_LOGGER.info "Finished (re)loading the desktops"
+end.execute

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -52,20 +52,20 @@
 # 'short_refresh_rate'. This will only detect desktops which have been
 # previously verified.
 #
-# All the desktops will be verified less frequently approximately according to
-# the 'refresh_rate'. This may run slightly more frequently than expected unless
-# 'refresh_rate' is a whole-interval of 'short_refresh_rate'.
+# All the desktops will be verified less frequently, at intervals no longer
+# than "refresh_rate". The "refresh_rate" should be a multiple of the
+# "short_refresh_rate", otherwise a different interval will be used. The
+# "refresh_rate" must be equal to or longer than the "short_refresh_rate".
 #
 # NOTE: As the avail/verify checks run periodically, a timeout is used to
 # ensure they run at regular intervals. This timeout is determined from the
 # "short_refresh_rate". Therefore the "short_refresh_rate" must be sufficiently
-# long to allow for all the desktops to be "verified". The "short_refresh_rate"
-# must also be less than or equal to the "refresh_rate".
+# long to allow for all the desktops to be "verified".
 #
 # The environment variables flight_DESKTOP_RESTAPI_refresh_rate and
 # flight_DESKTOP_RESTAPI_short_refresh_rate takes precedence.
 # =============================================================================
-# short_refresh_rate: 3600
+# short_refresh_rate: 300
 # refresh_rate: 3600
 
 # =============================================================================

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -45,28 +45,23 @@
 
 # =============================================================================
 # Refresh Rates
-# There are two refresh rates which are used to control how frequently the
-# available desktops are checked and verified.
+# The `refresh_rate` is used to control how frequently the available desktops
+# are checked and verified.
 #
-# The available desktops are checked frequently according to the
-# 'short_refresh_rate'. This will only detect desktops which have been
-# previously verified.
+# A quick check is made every `refresh_rate` seconds.  A full refresh is made
+# every `full_refresh` * `refresh_rate` seconds.
 #
-# All the desktops will be verified less frequently, at intervals no longer
-# than "refresh_rate". The "refresh_rate" should be a multiple of the
-# "short_refresh_rate", otherwise a different interval will be used. The
-# "refresh_rate" must be equal to or longer than the "short_refresh_rate".
+# A full refresh is required as the quick refresh may fail to correctly
+# identify that a desktop type is verified.
 #
-# NOTE: As the avail/verify checks run periodically, a timeout is used to
-# ensure they run at regular intervals. This timeout is determined from the
-# "short_refresh_rate". Therefore the "short_refresh_rate" must be sufficiently
-# long to allow for all the desktops to be "verified".
+# NOTE: The "refresh_rate" must be sufficiently long to allow for all the
+# desktops to be "verified".
 #
 # The environment variables flight_DESKTOP_RESTAPI_refresh_rate and
-# flight_DESKTOP_RESTAPI_short_refresh_rate takes precedence.
+# flight_DESKTOP_RESTAPI_full_refresh takes precedence.
 # =============================================================================
-# short_refresh_rate: 300
-# refresh_rate: 3600
+# refresh_rate: 300
+# full_refresh: 12
 
 # =============================================================================
 # Desktop Command

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -44,12 +44,28 @@
 # cors_domain:
 
 # =============================================================================
-# Refresh Rate
-# Sets how often the desktops are verified. It may take up to this length of
-# time before a desktop appears verified. Must be a time in seconds
+# Refresh Rates
+# There are two refresh rates which are used to control how frequently the
+# available desktops are checked and verified.
 #
-# The environment variable flight_DESKTOP_RESTAPI_refresh_rate takes precedence.
+# The available desktops are checked frequently according to the
+# 'short_refresh_rate'. This will only detect desktops which have been
+# previously verified.
+#
+# All the desktops will be verified less frequently approximately according to
+# the 'refresh_rate'. This may run slightly more frequently than expected unless
+# 'refresh_rate' is a whole-interval of 'short_refresh_rate'.
+#
+# NOTE: As the avail/verify checks run periodically, a timeout is used to
+# ensure they run at regular intervals. This timeout is determined from the
+# "short_refresh_rate". Therefore the "short_refresh_rate" must be sufficiently
+# long to allow for all the desktops to be "verified". The "short_refresh_rate"
+# must also be less than or equal to the "refresh_rate".
+#
+# The environment variables flight_DESKTOP_RESTAPI_refresh_rate and
+# flight_DESKTOP_RESTAPI_short_refresh_rate takes precedence.
 # =============================================================================
+# short_refresh_rate: 3600
 # refresh_rate: 3600
 
 # =============================================================================

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -26,16 +26,16 @@
 #===============================================================================
 
 # =============================================================================
-# Pam Configuration Name [DEFAULT]
+# Bind Address
 # Specify which pam configuration file should be used to authenticate requests.
 # It should correlate to a filename stored within /etc/pam.d
 #
-# The environment variable flight_DESKTOP_RESTAPI_pam_conf takes precedence.
+# The environment variable flight_DESKTOP_RESTAPI_bind_address takes precedence.
 # =============================================================================
-# pam_conf:
+# bind_address: tcp://127.0.0.1:915
 
 # =============================================================================
-# CORS Domain [OPTIONAL]
+# CORS Domain
 # Enable cross origin resource sharing from the given domain. CORS is disabled
 # by default
 #
@@ -50,13 +50,44 @@
 #
 # The environment variable flight_DESKTOP_RESTAPI_refresh_rate takes precedence.
 # =============================================================================
-# refresh_rate:
+# refresh_rate: 3600
 
 # =============================================================================
-# Log Level [DEFAULT]
+# Desktop Command
+#
+# The prefix used to run the flight-desktop command line utility
+#
+# The environment variable flight_DESKTOP_RESTAPI_desktop_command takes
+# precedence.
+# =============================================================================
+# desktop_command: flight desktop
+
+# =============================================================================
+# Shared Secret Path
+# The path to the file containing the shared secret used to verify the login
+# credentials.
+#
+# The environment variable flight_DESKTOP_RESTAPI_shared_secret_path takes
+# precedence.
+#
+# Relative paths are expanded from the installation directory.
+# =============================================================================
+# shared_secret_path: etc/shared-secret.conf
+
+# =============================================================================
+# SSO Cookie Domain
+# The name of cookie used to store the login credentials
+#
+# The environment variable flight_DESKTOP_RESTAPI_sso_cookie_domain takes
+# precedence.
+# =============================================================================
+# sso_cookie_name: flight_login
+
+# =============================================================================
+# Log Level
 # Specify which level of logging should be used. The supported values are:
 # fatal, error, warn, info, or debug
 #
 # The environment variable flight_DESKTOP_RESTAPI_log_level takes precedence.
 # =============================================================================
-# log_level:
+# log_level: info

--- a/lib/flight_desktop_restapi/configuration.rb
+++ b/lib/flight_desktop_restapi/configuration.rb
@@ -34,6 +34,7 @@ module FlightDesktopRestAPI
 
     attribute 'bind_address',       default: 'tcp://127.0.0.1:915'
     attribute 'cors_domain',        required: false
+    attribute 'short_refresh_rate', default: 300
     attribute 'refresh_rate',       default: 3600
     attribute 'log_level',          default: 'info'
     attribute 'shared_secret_path', default: 'etc/shared-secret.conf',

--- a/lib/flight_desktop_restapi/configuration.rb
+++ b/lib/flight_desktop_restapi/configuration.rb
@@ -34,8 +34,8 @@ module FlightDesktopRestAPI
 
     attribute 'bind_address',       default: 'tcp://127.0.0.1:915'
     attribute 'cors_domain',        required: false
-    attribute 'short_refresh_rate', default: 300
-    attribute 'refresh_rate',       default: 3600
+    attribute 'refresh_rate',       default: 300
+    attribute 'full_refresh',       default: 12
     attribute 'log_level',          default: 'info'
     attribute 'shared_secret_path', default: 'etc/shared-secret.conf',
                                     transform: relative_to(root_path)


### PR DESCRIPTION
The `flight desktop avail` command is now run more frequently then `flight desktop verify`.

This allows for system administrators to verify the desktops manually, and have the webapp reflect the change (reasonable) quickly.

The old loop has been replaced with a `Concurrent::TimerTask` as this has better reliability than a simple sleeping thread.

Both the "short" and "long" checks are preformed within a single `TimerTask`. This prevents race conditions between the two types of checks. However it does have two implications:

1. The "long running interval" has to be a multiple of the "short running internal", and
2. The "short running interval" needs to be sufficient long to allow all the `verify` tasks to finish.

---

Issue 1 is handled implicitly and should not cause a problem. There are two config settings which control the intervals: `refresh_rate` and `short_refresh_rate`. The _integer ratio_ between the two are used to determine how frequently `verify` should be ran. As integer division rounds down, this may cause `verify` to run slightly more frequently then expected.

Issue 2 is due to the timeout introduced by `Concurrent::TimerTask`. Using a `TimerTask` is ideal as it provides better error handling and makes the thread more robust. However it does mean the `verify` commands need to run within the timeout window created by `short_refresh_rate`. The commands should be sufficiently fast that this isn't an issue.

---

NOTE: This PR shares some commits with #42 , so one of them may need rebasing.