### PR TITLE
Prevent broken sessions from further breaking the API

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -145,9 +145,7 @@ class Session < Hashie::Trash
           #
           # To prevent things from unexpectedly breaking further, a bogus time is
           # used instead.
-          #
-          # Consider Refactoring.
-          session.last_accessed_at || Time.now
+          Time.at(0)
         end
       end
     end


### PR DESCRIPTION
Turns out the `metadata.yaml` file does not always exist. This causes the `ctime` check to fail and triggers an API error.

Currently everything assumes that `created_at` exists, so I do not want to break this assumption. So instead either the `last_access_at` or `Time.now` is used as a fallback.