### PR TITLE
Execute the flight command with an absolute path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,6 @@ gem 'flight_auth', github: "openflighthpc/flight_auth", branch: "297cb7241b820d3
 gem 'flight_configuration', github: 'openflighthpc/flight_configuration', branch: '24928260e542768f13cc513a3a08af69f690dfbc'
 gem 'hashie'
 gem 'puma'
-gem 'rpam-ruby19', require: 'rpam'
 gem 'sinatra', require: 'sinatra/base'
 gem 'sinatra-namespace'
 gem 'sinatra-cross_origin'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,7 +52,6 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
-    rpam-ruby19 (1.2.1)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -105,7 +104,6 @@ DEPENDENCIES
   pry-byebug
   puma
   rack-test
-  rpam-ruby19
   rspec
   rspec-collection_matchers
   sinatra

--- a/lib/flight_desktop_restapi/configuration.rb
+++ b/lib/flight_desktop_restapi/configuration.rb
@@ -40,7 +40,12 @@ module FlightDesktopRestAPI
     attribute 'shared_secret_path', default: 'etc/shared-secret.conf',
                                     transform: relative_to(root_path)
     attribute 'sso_cookie_name',    default: 'flight_login'
-    attribute 'desktop_command',    default: 'flight desktop'
+    attribute 'desktop_command',    default: ->() do
+      # TODO: Update to 'Flight.root' once migrated to the new version of
+      # flight_configuration
+      root = ENV.fetch('flight_ROOT', '/opt/flight')
+      "#{File.join(root, 'bin/flight')} desktop"
+    end
 
     def auth_decoder
       @auth_decoder ||= FlightAuth::Builder.new(shared_secret_path)


### PR DESCRIPTION
This means that `PATH` does not need to be overridden