### PR TITLE
Add routes for the user to fetch and modify their configurations

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -120,6 +120,12 @@ namespace '/ping' do
   end
 end
 
+namespace '/configs' do
+  get('/user') do
+    DesktopConfig.find(user: current_user).to_json
+  end
+end
+
 namespace '/desktops' do
   get do
     { 'data' => Desktop.index }.to_json

--- a/app.rb
+++ b/app.rb
@@ -122,7 +122,15 @@ end
 
 namespace '/configs' do
   get('/user') do
-    DesktopConfig.find(user: current_user).to_json
+    # There is no fetch command for configs in flight-desktop, only set
+    DesktopConfig.update(user: current_user).to_json
+  end
+
+  patch('/user') do
+    update = params.slice('geometry', 'desktop')
+                   .map { |k, v| [k.to_sym, v] }
+                   .to_h
+    DesktopConfig.update(**update, user: current_user).to_json
   end
 end
 

--- a/app.rb
+++ b/app.rb
@@ -177,7 +177,11 @@ namespace '/sessions' do
 
   post do
     status 201
-    current_desktop.start_session!(user: current_user).to_json
+    if params[:desktop]
+      current_desktop.start_session!(user: current_user).to_json
+    else
+      Session.start_default(user: current_user).to_json
+    end
   end
 
   namespace('/:id') do

--- a/app.rb
+++ b/app.rb
@@ -179,7 +179,7 @@ namespace '/sessions' do
     if params[:desktop]
       current_desktop.start_session!(user: current_user).to_json
     else
-      Session.start_default(user: current_user).to_json
+      Desktop.default(user: current_user).start_session!(user: current_user).to_json
     end
   end
 

--- a/app.rb
+++ b/app.rb
@@ -122,8 +122,7 @@ end
 
 namespace '/configs' do
   get('/user') do
-    # There is no fetch command for configs in flight-desktop, only set
-    DesktopConfig.update(user: current_user).to_json
+    DesktopConfig.fetch(user: current_user).to_json
   end
 
   patch('/user') do

--- a/app/models.rb
+++ b/app/models.rb
@@ -30,6 +30,35 @@
 require 'base64'
 require 'time'
 
+class DesktopConfig < Hashie::Trash
+  include Hashie::Extensions::Dash::Coercion
+
+  def self.find(user:)
+    cmd = SystemCommand.set(user: user)
+    if cmd.success?
+      parts = cmd.stdout.split("\n").map { |s| s.split("\s").last }
+      new(desktop: parts.first, geometry: parts[1])
+    else
+      raise InternalServerError
+    end
+  end
+
+  property :desktop
+  property :geometry
+
+  def as_json(_ = {})
+    {
+      'id' => 'user',
+      'desktop' => desktop,
+      'geometry' => geometry
+    }
+  end
+
+  def to_json
+    as_json.to_json
+  end
+end
+
 class Session < Hashie::Trash
   include Hashie::Extensions::Dash::Coercion
 

--- a/app/models.rb
+++ b/app/models.rb
@@ -110,6 +110,15 @@ class Session < Hashie::Trash
     end
   end
 
+  def self.start_default(user:)
+    cmd = SystemCommand.start_session(user: user)
+    if cmd.success?
+      build_from_output(cmd.stdout.split("\n"), user: user)
+    else
+      raise InternalServerError
+    end
+  end
+
   def self.build_from_output(lines, user:)
     lines = lines.split("\n") if lines.is_a?(String)
     data = lines.each_with_object({}) do |line, memo|

--- a/app/models.rb
+++ b/app/models.rb
@@ -33,8 +33,8 @@ require 'time'
 class DesktopConfig < Hashie::Trash
   include Hashie::Extensions::Dash::Coercion
 
-  def self.find(user:)
-    cmd = SystemCommand.set(user: user)
+  def self.update(user:, **opts)
+    cmd = SystemCommand.set(user: user, **opts)
     if cmd.success?
       parts = cmd.stdout.split("\n").map { |s| s.split("\s").last }
       new(desktop: parts.first, geometry: parts[1])

--- a/app/models.rb
+++ b/app/models.rb
@@ -43,6 +43,11 @@ class DesktopConfig < Hashie::Trash
     end
   end
 
+  class << self
+    # There is no fetch command for configs in flight-desktop, only set
+    alias_method :fetch, :update
+  end
+
   property :desktop
   property :geometry
 

--- a/app/models.rb
+++ b/app/models.rb
@@ -115,15 +115,6 @@ class Session < Hashie::Trash
     end
   end
 
-  def self.start_default(user:)
-    cmd = SystemCommand.start_session(user: user)
-    if cmd.success?
-      build_from_output(cmd.stdout.split("\n"), user: user)
-    else
-      raise InternalServerError
-    end
-  end
-
   def self.build_from_output(lines, user:)
     lines = lines.split("\n") if lines.is_a?(String)
     data = lines.each_with_object({}) do |line, memo|
@@ -246,6 +237,11 @@ class Desktop < Hashie::Trash
 
   def self.[](key)
     cache[key]
+  end
+
+  def self.default(user:)
+    config = DesktopConfig.fetch(user: user)
+    self[config.desktop]
   end
 
   private_class_method

--- a/app/models.rb
+++ b/app/models.rb
@@ -55,7 +55,8 @@ class DesktopConfig < Hashie::Trash
     {
       'id' => 'user',
       'desktop' => desktop,
-      'geometry' => geometry
+      'geometry' => geometry,
+      'geometries' => FlightDesktopRestAPI.config.xrandr_geometries
     }
   end
 

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -129,6 +129,10 @@ class SystemCommand < Hashie::Dash
     Builder.new("#{FlightDesktopRestAPI.config.desktop_command} avail").call(user: user)
   end
 
+  def self.set(user:)
+    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} set").call(user: user)
+  end
+
   def self.version(user:)
     Builder.new("#{FlightDesktopRestAPI.config.desktop_command} --version").call(user: user)
   end

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -105,8 +105,9 @@ class SystemCommand < Hashie::Dash
     Builder.new("#{FlightDesktopRestAPI.config.desktop_command} show").call(id, user: user)
   end
 
-  def self.start_session(desktop, user:)
-    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} start").call(desktop, user: user)
+  def self.start_session(desktop = nil, user:)
+    params = [desktop].reject(&:nil?)
+    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} start").call(*params, user: user)
   end
 
   def self.webify_session(id, user:)
@@ -132,8 +133,8 @@ class SystemCommand < Hashie::Dash
   def self.set(desktop: nil, geometry: nil, user:)
     params = {
       desktop: desktop, geometry: geometry
-    }.reject { |_, v| v.nil? }.map { |k, v| "#{k}=#{v}" }.join(" ")
-    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} set #{params}").call(user: user)
+    }.reject { |_, v| v.nil? }.map { |k, v| "#{k}=#{v}" }
+    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} set").call(*params, user: user)
   end
 
   def self.version(user:)

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -129,8 +129,11 @@ class SystemCommand < Hashie::Dash
     Builder.new("#{FlightDesktopRestAPI.config.desktop_command} avail").call(user: user)
   end
 
-  def self.set(user:)
-    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} set").call(user: user)
+  def self.set(desktop: nil, geometry: nil, user:)
+    params = {
+      desktop: desktop, geometry: geometry
+    }.reject { |_, v| v.nil? }.map { |k, v| "#{k}=#{v}" }.join(" ")
+    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} set #{params}").call(user: user)
   end
 
   def self.version(user:)

--- a/app/system_command.rb
+++ b/app/system_command.rb
@@ -105,9 +105,8 @@ class SystemCommand < Hashie::Dash
     Builder.new("#{FlightDesktopRestAPI.config.desktop_command} show").call(id, user: user)
   end
 
-  def self.start_session(desktop = nil, user:)
-    params = [desktop].reject(&:nil?)
-    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} start").call(*params, user: user)
+  def self.start_session(desktop, user:)
+    Builder.new("#{FlightDesktopRestAPI.config.desktop_command} start").call(desktop, user: user)
   end
 
   def self.webify_session(id, user:)

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -80,6 +80,28 @@ HTTP/2 200 OK
 }
 ```
 
+### PATCH Update
+
+Update the configuration.
+
+``
+PATCH /configs/user
+Authorization: Bearer <token>
+Content-Type: application/json
+Accepts: application/json
+{
+  "desktop": [new-desktop-type],
+  "geometry": [new-geometry]
+}
+
+HTTP/2 200 OK
+{
+  "id": "user",
+  "desktop": <desktop-type>,
+  "geometry": <geometry>
+}
+```
+
 ## Sessions
 
 ### ID

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -61,6 +61,25 @@ Content-Type: application/json
 }
 ```
 
+## Configs
+
+### GET Show
+
+Returns the default configuration for the user.
+
+```
+GET /configs/user
+Authorization: Bearer <token>
+Accepts: application/json
+
+HTTP/2 200 OK
+{
+  "id": "user",
+  "desktop": <desktop-type>,
+  "geometry": <geometry>
+}
+```
+
 ## Sessions
 
 ### ID

--- a/docs/routes.md
+++ b/docs/routes.md
@@ -76,7 +76,11 @@ HTTP/2 200 OK
 {
   "id": "user",
   "desktop": <desktop-type>,
-  "geometry": <geometry>
+  "geometry": <geometry>,
+  "geometries": [
+    <geometry>,
+    ...
+  ]
 }
 ```
 

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -102,3 +102,29 @@
 # The environment variable flight_DESKTOP_RESTAPI_log_level takes precedence.
 # =============================================================================
 # log_level: info
+
+# =============================================================================
+# Available XRandR Geometries
+# Specifies the available geometries for the desktops. This maybe an array or
+# comma separated string.
+#
+# The environment variable flight_DESKTOP_RESTAPI_xrandr_geometries takes
+# precedence.
+#
+# NOTE: These geometries will need to be available on all desktops which are
+#       accessible via flight-desktop.
+# =============================================================================
+# xrandr_geometries:
+#   - 1920x1200
+#   - 1920x1080
+#   - 1600x1200
+#   - 1680x1050
+#   - 1400x1050
+#   - 1360x768
+#   - 1280x1024
+#   - 1280x960
+#   - 1280x800
+#   - 1280x720
+#   - 1024x768
+#   - 800x600
+#   - 640x480

--- a/lib/flight_desktop_restapi/configuration.rb
+++ b/lib/flight_desktop_restapi/configuration.rb
@@ -46,6 +46,23 @@ module FlightDesktopRestAPI
       root = ENV.fetch('flight_ROOT', '/opt/flight')
       "#{File.join(root, 'bin/flight')} desktop"
     end
+    attribute 'xrandr_geometries',
+      transform: ->(v) { v.is_a?(Array) ? v : v.to_s.split(',') },
+      default: [
+        "1920x1200",
+        "1920x1080",
+        "1600x1200",
+        "1680x1050",
+        "1400x1050",
+        "1360x768",
+        "1280x1024",
+        "1280x960",
+        "1280x800",
+        "1280x720",
+        "1024x768",
+        "800x600",
+        "640x480"
+      ]
 
     def auth_decoder
       @auth_decoder ||= FlightAuth::Builder.new(shared_secret_path)


### PR DESCRIPTION
Fairly straight forward addition of two new routes:

* `GET /configs/user` - Get the current state of the user's config,
* `PATCH /configs/user` - Update the user's config

Currently `flight desktop` does not support a method for getting the user's configuration. So instead the `set` method needs to be re-purposed as a `fetch`.

---

The `desktop` input to `POST /desktops` is now optional. The default desktop will be used when omitted.