### PR TITLE
Integrate within flight-desktop post-verify scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 /vendor
 etc/*.local.yaml
 etc/shared-secret.*
+libexec/desktop-restapi/reload-desktop-restapi
+libexec/desktop/*
 
 # NOTE: This is a general ignore all yaml files in the config directory
 # There are a couple of configs which have manually be checked in

--- a/app/models.rb
+++ b/app/models.rb
@@ -240,6 +240,18 @@ class Desktop < Hashie::Trash
     cache[key]
   end
 
+  def self.avail
+    SystemCommand.avail_desktops(user: ENV['USER'])
+                 .tap(&:raise_unless_successful)
+                 .stdout
+                 .each_line.map do |line|
+      data = line.split("\t")
+      home = data[2].empty? ? nil : data[2]
+      verified = (data[3].chomp == 'Verified')
+      new(name: data[0], summary: data[1], homepage: home, verified: verified)
+    end
+  end
+
   def self.default(user:)
     config = DesktopConfig.fetch(user: user)
     self[config.desktop]

--- a/config.ru
+++ b/config.ru
@@ -43,6 +43,11 @@ configure do
   enable :logging
 end
 
+at_exit do
+  # Disable the flight-desktop integration on exit
+  FileUtils.rm_f FlightDesktopRestAPI.config.integrated_reload_dst
+end
+
 app = Rack::Builder.new do
   map('/v2') { run Sinatra::Application }
 end

--- a/config.ru
+++ b/config.ru
@@ -43,11 +43,6 @@ configure do
   enable :logging
 end
 
-at_exit do
-  # Disable the flight-desktop integration on exit
-  FileUtils.rm_f FlightDesktopRestAPI.config.integrated_reload_dst
-end
-
 app = Rack::Builder.new do
   map('/v2') { run Sinatra::Application }
 end

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -57,8 +57,8 @@ Concurrent::TimerTask.new(**opts) do |task|
   end
 
   # Re-load the desktops to ensure the verified status is up to date
-  # This prevents race conditions between the first verify running
-  # whilst the integration is disabled
+  # This prevents a race condition if another desktop is verified whilst
+  # the integration is disabled
   hash = Desktop.avail.map { |m| [m.name, m] }.to_h
   Desktop.instance_variable_set(:@cache, hash)
 

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -33,33 +33,17 @@ return if ENV['RACK_ENV'] == 'test'
 first = true
 
 # Periodically reload and verify the desktops
-# NOTE: This shouldn't have a timeout as it risks the trap not being reset
-#       Instead this should run in-frequently enough that a timeout isn't required
 opts = {
   execution_interval: FlightDesktopRestAPI.config.refresh_rate,
+  timeout_interval: (FlightDesktopRestAPI.config.refresh_rate - 1),
   run_now: true
 }
 Concurrent::TimerTask.new(**opts) do |task|
-  # Get the current available desktops
+  # Determine which desktops are available.  A `verify --force` is ran for
+  # each desktop to ensure we have an accurate list.
   models = Desktop.avail
-
-  begin
-    # Disable the reload integration with flight-desktop
-    FileUtils.rm_f FlightDesktopRestAPI.config.integrated_reload_dst
-
-    # Verify each of the desktops
-    models.each { |m| m.verify_desktop(user: ENV['USER']) }
-  ensure
-    # Re-enable the reload integration with flight-desktop
-    FileUtils.mkdir_p File.dirname(FlightDesktopRestAPI.config.integrated_reload_dst)
-    FileUtils.ln_sf FlightDesktopRestAPI.config.integrated_reload_src, \
-      FlightDesktopRestAPI.config.integrated_reload_dst
-  end
-
-  # Re-load the desktops to ensure the verified status is up to date
-  # This prevents a race condition if another desktop is verified whilst
-  # the integration is disabled
-  hash = Desktop.avail.map { |m| [m.name, m] }.to_h
+  models.each { |m| m.verify_desktop(user: ENV['USER']) }
+  hash = models.map { |m| [m.name, m] }.to_h
   Desktop.instance_variable_set(:@cache, hash)
 
   DEFAULT_LOGGER.info "Finished #{'re' unless first}loading the desktops"

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -49,10 +49,6 @@ Concurrent::TimerTask.new(**opts) do |task|
 
     # Verify each of the desktops
     models.each { |m| m.verify_desktop(user: ENV['USER']) }
-
-    DEFAULT_LOGGER.info "Finished #{'re' unless first}loading the desktops"
-    first = false
-
   ensure
     # Re-enable the reload integration with flight-desktop
     FileUtils.mkdir_p File.dirname(FlightDesktopRestAPI.config.integrated_reload_dst)
@@ -65,4 +61,7 @@ Concurrent::TimerTask.new(**opts) do |task|
   # whilst the integration is disabled
   hash = Desktop.avail.map { |m| [m.name, m] }.to_h
   Desktop.instance_variable_set(:@cache, hash)
+
+  DEFAULT_LOGGER.info "Finished #{'re' unless first}loading the desktops"
+  first = false
 end.execute

--- a/config/initializers/desktop_types.rb
+++ b/config/initializers/desktop_types.rb
@@ -49,8 +49,6 @@ Concurrent::TimerTask.new(**opts) do |task|
 
     # Verify each of the desktops
     models.each { |m| m.verify_desktop(user: ENV['USER']) }
-    hash = models.map { |m| [m.name, m] }.to_h
-    Desktop.instance_variable_set(:@cache, hash)
 
     DEFAULT_LOGGER.info "Finished #{'re' unless first}loading the desktops"
     first = false
@@ -61,4 +59,10 @@ Concurrent::TimerTask.new(**opts) do |task|
     FileUtils.ln_sf FlightDesktopRestAPI.config.integrated_reload_src, \
       FlightDesktopRestAPI.config.integrated_reload_dst
   end
+
+  # Re-load the desktops to ensure the verified status is up to date
+  # This prevents race conditions between the first verify running
+  # whilst the integration is disabled
+  hash = Desktop.avail.map { |m| [m.name, m] }.to_h
+  Desktop.instance_variable_set(:@cache, hash)
 end.execute

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -90,6 +90,30 @@
 # sso_cookie_name: flight_login
 
 # =============================================================================
+# Integrated Reload Source/Destination
+# There is an integration point between flight-deskopt-restapi and
+# flight-desktop which will reload the service when a new desktop is verified.
+#
+# The restapi needs control over this integration to prevent it getting caught
+# in a reload loop.
+#
+# The integrated_reload_src should be a script that will trigger the service
+# to restart. This script must not be located within flight-desktop hooks
+# directory.
+#
+# The integrated_reload_dst is the location the script will be linked to this.
+# This will enable the integration and should be within flight-desktop hook
+# directory.
+#
+# The environment variables flight_DESKTOP_RESTAPI_integrated_reload_src and
+# flight_DESKTOP_RESTAPI_integrated_reload_dst will take precedence.
+#
+# Relative paths are expanded from the installation directory.
+# =============================================================================
+# integrated_reload_src: libexec/desktop-restapi/reload-desktop-restapi
+# integrated_reload_dst: libexec/desktop/hooks/post-verify/reload-desktop-restapi
+
+# =============================================================================
 # Log Level
 # Specify which level of logging should be used. The supported values are:
 # fatal, error, warn, info, or debug

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -49,12 +49,8 @@
 # are checked and verified.This check will be made at intervals given by the
 # 'refresh_rate'.
 #
-# The environment variables flight_DESKTOP_RESTAPI_refresh_rate and
-# flight_DESKTOP_RESTAPI_full_refresh takes precedence.
-#
-# DEPRECATED: Obsolete full_refresh config
-# Previously there were two types of checks: a "quick" and "full". The quick
-# refreshes are no longer required, so all checks will be a "full refresh".
+# The environment variable flight_DESKTOP_RESTAPI_refresh_rate takes
+# precedence.
 # =============================================================================
 # refresh_rate: 3600
 
@@ -88,30 +84,6 @@
 # precedence.
 # =============================================================================
 # sso_cookie_name: flight_login
-
-# =============================================================================
-# Integrated Reload Source/Destination
-# There is an integration point between flight-deskopt-restapi and
-# flight-desktop which will reload the service when a new desktop is verified.
-#
-# The restapi needs control over this integration to prevent it getting caught
-# in a reload loop.
-#
-# The integrated_reload_src should be a script that will trigger the service
-# to restart. This script must not be located within flight-desktop hooks
-# directory.
-#
-# The integrated_reload_dst is the location the script will be linked to this.
-# This will enable the integration and should be within flight-desktop hook
-# directory.
-#
-# The environment variables flight_DESKTOP_RESTAPI_integrated_reload_src and
-# flight_DESKTOP_RESTAPI_integrated_reload_dst will take precedence.
-#
-# Relative paths are expanded from the installation directory.
-# =============================================================================
-# integrated_reload_src: libexec/desktop-restapi/reload-desktop-restapi
-# integrated_reload_dst: libexec/desktop/hooks/post-verify/reload-desktop-restapi
 
 # =============================================================================
 # Log Level

--- a/etc/flight-desktop-restapi.yaml
+++ b/etc/flight-desktop-restapi.yaml
@@ -46,22 +46,17 @@
 # =============================================================================
 # Refresh Rates
 # The `refresh_rate` is used to control how frequently the available desktops
-# are checked and verified.
-#
-# A quick check is made every `refresh_rate` seconds.  A full refresh is made
-# every `full_refresh` * `refresh_rate` seconds.
-#
-# A full refresh is required as the quick refresh may fail to correctly
-# identify that a desktop type is verified.
-#
-# NOTE: The "refresh_rate" must be sufficiently long to allow for all the
-# desktops to be "verified".
+# are checked and verified.This check will be made at intervals given by the
+# 'refresh_rate'.
 #
 # The environment variables flight_DESKTOP_RESTAPI_refresh_rate and
 # flight_DESKTOP_RESTAPI_full_refresh takes precedence.
+#
+# DEPRECATED: Obsolete full_refresh config
+# Previously there were two types of checks: a "quick" and "full". The quick
+# refreshes are no longer required, so all checks will be a "full refresh".
 # =============================================================================
-# refresh_rate: 300
-# full_refresh: 12
+# refresh_rate: 3600
 
 # =============================================================================
 # Desktop Command

--- a/lib/flight_desktop_restapi/configuration.rb
+++ b/lib/flight_desktop_restapi/configuration.rb
@@ -34,8 +34,7 @@ module FlightDesktopRestAPI
 
     attribute 'bind_address',       default: 'tcp://127.0.0.1:915'
     attribute 'cors_domain',        required: false
-    attribute 'refresh_rate',       default: 300
-    attribute 'full_refresh',       default: 12
+    attribute 'refresh_rate',       default: 3600
     attribute 'log_level',          default: 'info'
     attribute 'shared_secret_path', default: 'etc/shared-secret.conf',
                                     transform: relative_to(root_path)

--- a/lib/flight_desktop_restapi/configuration.rb
+++ b/lib/flight_desktop_restapi/configuration.rb
@@ -63,6 +63,13 @@ module FlightDesktopRestAPI
         "640x480"
       ]
 
+    attribute 'integrated_reload_src',
+      default: 'libexec/desktop-restapi/reload-desktop-restapi',
+      transform: relative_to(root_path)
+    attribute 'integrated_reload_dst',
+      default: 'libexec/desktop/hooks/post-verify/reload-desktop-restapi',
+      transform: relative_to(root_path)
+
     def auth_decoder
       @auth_decoder ||= FlightAuth::Builder.new(shared_secret_path)
     end

--- a/lib/flight_desktop_restapi/configuration.rb
+++ b/lib/flight_desktop_restapi/configuration.rb
@@ -63,13 +63,6 @@ module FlightDesktopRestAPI
         "640x480"
       ]
 
-    attribute 'integrated_reload_src',
-      default: 'libexec/desktop-restapi/reload-desktop-restapi',
-      transform: relative_to(root_path)
-    attribute 'integrated_reload_dst',
-      default: 'libexec/desktop/hooks/post-verify/reload-desktop-restapi',
-      transform: relative_to(root_path)
-
     def auth_decoder
       @auth_decoder ||= FlightAuth::Builder.new(shared_secret_path)
     end


### PR DESCRIPTION
Short polling of `flight-desktop avail` has been removed as it in favour of post verify scripts. This allows `flight-desktop` to reload `flight-desktop-restapi` on demand.

However as `flight-desktop-restapi` calls `flight-desktop` this can create a loop. Therefore, the integration needs to be disabled before calling `flight-desktop verify` and re-enable at the end.