### PR TITLE
Workaround bad configuration breaking pumactl

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -31,6 +31,9 @@ require_relative 'config/boot.rb'
 
 require 'sinatra'
 
+# Ensures the shared secret exists
+Flight.config.auth_decoder
+
 configure do
   set :show_exceptions, :after_handler
   set :logger, DEFAULT_LOGGER

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -47,12 +47,8 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'flight_desktop_restapi'
 require_relative 'initializers/logger'
 
-# Ensures the shared secret exists
-FlightDesktopRestAPI.config.auth_decoder
-
 require_relative '../app/system_command'
 require_relative '../app/errors'
 require_relative '../app/models'
 require_relative 'initializers/desktop_types'
 require_relative '../app'
-


### PR DESCRIPTION
If an exception is raised whilst loading `config/puma.rb` the `pumactl` script can become broken.  In particular when attempting to stop the service.

However, we want bad configurations to prevent the service from starting.  The code checking for bad configuration has been moved from `config/boot.rb` to `config.ru` such that it will only run when the service is started.