### PR TITLE
Add name property to session model

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -88,7 +88,8 @@ class Session < Hashie::Trash
           last_accessed_at: parts[10],
           screenshot_path: parts[11],
           user: user,
-          ips: (parts[12] || "").split("|")
+          ips: (parts[12] || "").split("|"),
+          name: parts[13]
         )
       end
     else
@@ -150,6 +151,8 @@ class Session < Hashie::Trash
       when 'IPs'
         value = value.split("|")
         :ips
+      when 'Name'
+        :name
       else
         next # Ignore any extraneous keys
       end
@@ -168,6 +171,7 @@ class Session < Hashie::Trash
   property :password
   property :user
   property :state
+  property :name
   property :created_at, transform_with: ->(time) {
     case time
     when Time
@@ -223,7 +227,8 @@ class Session < Hashie::Trash
       'password' => password,
       'state' => state,
       'created_at' => created_at&.rfc3339,
-      'last_accessed_at' => last_accessed_at&.rfc3339
+      'last_accessed_at' => last_accessed_at&.rfc3339,
+      'name' => name
     }.tap do |h|
       h['screenshot'] = screenshot ? Base64.encode64(screenshot) : nil
     end

--- a/app/models.rb
+++ b/app/models.rb
@@ -152,6 +152,7 @@ class Session < Hashie::Trash
         value = value.split("|")
         :ips
       when 'Name'
+        value = nil if value.blank?
         :name
       else
         next # Ignore any extraneous keys


### PR DESCRIPTION
This PR aims to add the newly realised `name` attribute to the `Session` model, so that it can be exposed to the Flight Desktop Webapp.