### PR TITLE
Desktop naming/renaming

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -189,12 +189,21 @@ namespace '/sessions' do
         params[:id]
       end
 
+      def name_param
+        params[:name]
+      end
+
       def current_session
         Session.find(id_param, user: current_user).tap do |s|
           next if s
           raise NotFound.new(type: 'session', id: id_param)
         end
       end
+    end
+
+    post '/rename' do
+      status 200
+      current_session.rename(name: name_param)
     end
 
     get do

--- a/app.rb
+++ b/app.rb
@@ -177,7 +177,7 @@ namespace '/sessions' do
   post do
     status 201
     if params[:desktop]
-      current_desktop.start_session!(user: current_user).to_json
+      current_desktop.start_session!(user: current_user, session_name: params[:name]).to_json
     else
       Desktop.default(user: current_user).start_session!(user: current_user).to_json
     end

--- a/app.rb
+++ b/app.rb
@@ -66,6 +66,10 @@ end
 
 helpers do
   attr_accessor :current_user
+
+  def name_param
+    params[:name]
+  end
 end
 
 # Validates the user's credentials from the authorization header
@@ -187,10 +191,6 @@ namespace '/sessions' do
     helpers do
       def id_param
         params[:id]
-      end
-
-      def name_param
-        params[:name]
       end
 
       def current_session

--- a/app.rb
+++ b/app.rb
@@ -177,7 +177,7 @@ namespace '/sessions' do
   post do
     status 201
     if params[:desktop]
-      current_desktop.start_session!(user: current_user, session_name: params[:name]).to_json
+      current_desktop.start_session!(user: current_user, session_name: name_param).to_json
     else
       Desktop.default(user: current_user).start_session!(user: current_user).to_json
     end

--- a/app/models.rb
+++ b/app/models.rb
@@ -251,6 +251,14 @@ class Session < Hashie::Trash
     end
   end
 
+  def rename(name:)
+    if DesktopCLI.rename_session(id, name: name, user: user, remote_host: remote_host).success?
+      true
+    else
+      raise InternalServerError.new(details: 'failed to rename the session')
+    end
+  end
+
   def remote_host
     remote? ? hostname : nil
   end

--- a/app/models.rb
+++ b/app/models.rb
@@ -327,11 +327,11 @@ class Desktop < Hashie::Trash
   #         This makes the toggle brittle as a minor change in error message
   #         could break the regex match. Instead `flight desktop` should be
   #         updated to return different exit codes
-  def start_session!(user:)
-    cmd = DesktopCLI.start_session(name, user: user)
+  def start_session!(user:, session_name: nil)
+    cmd = DesktopCLI.start_session(name, user: user, session_name: session_name)
     if /verified\Z/ =~ cmd.stderr
       verify_desktop!(user: user)
-      cmd = DesktopCLI.start_session(name, user: user)
+      cmd = DesktopCLI.start_session(name, user: user, session_name: session_name)
     end
     raise InternalServerError unless cmd.success?
     Session.build_from_output(cmd.stdout.split("\n"), user: user)

--- a/lib/flight_desktop_restapi/desktop_cli.rb
+++ b/lib/flight_desktop_restapi/desktop_cli.rb
@@ -51,9 +51,9 @@ module FlightDesktopRestAPI
 
       def start_session(desktop, user:, session_name: nil)
         if remote_host = select_remote_host(user)
-          new(*flight_desktop, 'start', desktop, "--name", session_name, user: user).run_remote(remote_host)
+          new(*flight_desktop, 'start', desktop, *name_param(session_name), user: user).run_remote(remote_host)
         else
-          new(*flight_desktop, 'start', desktop, "--name", session_name, user: user).run_local
+          new(*flight_desktop, 'start', desktop, *name_param(session_name), user: user).run_local
         end
       end
 
@@ -109,6 +109,10 @@ module FlightDesktopRestAPI
 
       def flight_desktop
         Flight.config.desktop_command
+      end
+
+      def name_param(session_name)
+	["--name", session_name] if session_name
       end
     end
 

--- a/lib/flight_desktop_restapi/desktop_cli.rb
+++ b/lib/flight_desktop_restapi/desktop_cli.rb
@@ -112,7 +112,7 @@ module FlightDesktopRestAPI
       end
 
       def name_param(session_name)
-	["--name", session_name] if session_name
+        ["--name", session_name] if !session_name.blank?
       end
     end
 
@@ -137,7 +137,7 @@ module FlightDesktopRestAPI
             env: @env,
             logger: Flight.logger,
             timeout: @timeout,
-            username: @user
+            username: @user,
           )
           process.run(@cmd, @stdin, &block)
         end
@@ -160,7 +160,7 @@ module FlightDesktopRestAPI
             logger: Flight.logger,
             public_key_path: public_key_path,
             timeout: @timeout,
-            username: @user
+            username: @user,
           )
           process.run(@cmd, @stdin, &block)
         end

--- a/lib/flight_desktop_restapi/desktop_cli.rb
+++ b/lib/flight_desktop_restapi/desktop_cli.rb
@@ -57,6 +57,14 @@ module FlightDesktopRestAPI
         end
       end
 
+      def rename_session(id, name:, user:, remote_host:)
+        if remote_host
+          new(*flight_desktop, 'rename', id, name, user: user).run_remote(remote_host)
+        else
+          new(*flight_desktop, 'rename', id, name, user: user).run_local
+        end
+      end
+
       def webify_session(id, user:, remote_host:)
         if remote_host
           new(*flight_desktop, 'webify', id, user: user).run_remote(remote_host)

--- a/lib/flight_desktop_restapi/desktop_cli.rb
+++ b/lib/flight_desktop_restapi/desktop_cli.rb
@@ -49,11 +49,11 @@ module FlightDesktopRestAPI
         new(*flight_desktop, 'show', id, user: user).run_local
       end
 
-      def start_session(desktop, user:)
+      def start_session(desktop, user:, session_name: nil)
         if remote_host = select_remote_host(user)
-          new(*flight_desktop, 'start', desktop, user: user).run_remote(remote_host)
+          new(*flight_desktop, 'start', desktop, "--name", session_name, user: user).run_remote(remote_host)
         else
-          new(*flight_desktop, 'start', desktop, user: user).run_local
+          new(*flight_desktop, 'start', desktop, "--name", session_name, user: user).run_local
         end
       end
 
@@ -133,7 +133,7 @@ module FlightDesktopRestAPI
             env: @env,
             logger: Flight.logger,
             timeout: @timeout,
-            username: @user,
+            username: @user
           )
           process.run(@cmd, @stdin, &block)
         end
@@ -156,7 +156,7 @@ module FlightDesktopRestAPI
             logger: Flight.logger,
             public_key_path: public_key_path,
             timeout: @timeout,
-            username: @user,
+            username: @user
           )
           process.run(@cmd, @stdin, &block)
         end

--- a/lib/flight_desktop_restapi/desktop_cli.rb
+++ b/lib/flight_desktop_restapi/desktop_cli.rb
@@ -120,7 +120,7 @@ module FlightDesktopRestAPI
       end
 
       def name_param(session_name)
-        ["--name", session_name] if !session_name.blank?
+        ["--name", session_name] unless session_name.blank?
       end
     end
 


### PR DESCRIPTION
This PR adds modifies the `start_session` route to accept an optional name parameter, and adds a new route to allow for desktop session renaming.