### PR TITLE
Fix dev CLI error reporting of unprepared desktops

### DIFF
--- a/app/models.rb
+++ b/app/models.rb
@@ -349,7 +349,7 @@ class Desktop < Hashie::Trash
     cmd = DesktopCLI.verify_desktop(name, user: user)
     self.verified = if /already been verified\.\Z/ =~ cmd.stdout.chomp
       true
-    elsif /flight desktop prepare/ =~ cmd.stdout
+    elsif /^\s*(flight)? desktop prepare\b/ =~ cmd.stdout
       false
     elsif cmd.success?
       true


### PR DESCRIPTION
Previously, detecting the error only worked for the RPM installed version of flight desktop.  Now we work for the dev version too.