### PR TITLE
Add endpoint for session configure

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -215,6 +215,11 @@ namespace '/sessions' do
       current_session.resize(geometry: geometry_param)
     end
 
+    post '/configure' do
+      status 200
+      current_session.configure(name: name_param, geometry: geometry_param)
+    end
+
     get do
       current_session.tap { |s| s.load_screenshot if include_screenshot? }
                      .to_json

--- a/app/models.rb
+++ b/app/models.rb
@@ -283,6 +283,21 @@ class Session < Hashie::Trash
     end
   end
 
+  def configure(name:, geometry:)
+    if DesktopCLI.configure_session(
+        id,
+        name: name,
+        geometry: geometry,
+        user: user,
+        remote_host: remote_host
+    ).success?
+      true
+    else
+      raise InternalServerError.new(detail: 'failed to configure the session')
+    end
+  end
+
+
   def remote_host
     remote? ? hostname : nil
   end

--- a/lib/flight_desktop_restapi/desktop_cli.rb
+++ b/lib/flight_desktop_restapi/desktop_cli.rb
@@ -73,6 +73,11 @@ module FlightDesktopRestAPI
         end
       end
 
+      def configure_session(id, geometry:, name:, user:, remote_host:)
+        rename_session(id, name: name, user: user, remote_host: remote_host)
+        resize_session(id, geometry: geometry, user: user, remote_host: remote_host)
+      end
+
       def webify_session(id, user:, remote_host:)
         if remote_host
           new(*flight_desktop, 'webify', id, user: user).run_remote(remote_host)

--- a/lib/flight_desktop_restapi/desktop_cli.rb
+++ b/lib/flight_desktop_restapi/desktop_cli.rb
@@ -74,6 +74,12 @@ module FlightDesktopRestAPI
       end
 
       def configure_session(id, geometry:, name:, user:, remote_host:)
+        # Currently, the webapp and the API have no knowledge of which
+        # desktop types support being resized.  This causes something of an
+        # issue when trying to configure such a session.  Currently, we return
+        # only the success of the resize attempt, allowing the webapp to
+        # report whether the session was resized or not.  This should
+        # obviously be changed at some point.
         rename_session(id, name: name, user: user, remote_host: remote_host)
         resize_session(id, geometry: geometry, user: user, remote_host: remote_host)
       end


### PR DESCRIPTION
This PR adds a new endpoint to `/sessions/[:id]` to allow multiple (and at the moment, all) session configuration options to be set in a single API call.