### PR TITLE
Add ed25519 and bcrypt gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,10 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 gem 'activemodel', require: 'active_model'
 gem 'activesupport', require: 'active_support/all'
+gem 'bcrypt_pbkdf'
 gem 'concurrent-ruby'
 gem 'dotenv'
+gem 'ed25519'
 gem 'flight_auth', github: "openflighthpc/flight_auth", branch: "297cb7241b820d334e5d593c4e237a81b83a9995"
 gem 'flight_configuration', github: 'openflighthpc/flight_configuration', tag: '0.6.1', branch: 'master'
 gem 'hashie'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,11 +25,13 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
+    bcrypt_pbkdf (1.1.0)
     byebug (11.1.3)
     coderay (1.1.3)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
     dotenv (2.7.6)
+    ed25519 (1.3.0)
     fakefs (1.5.1)
     hashie (5.0.0)
     i18n (1.10.0)
@@ -98,8 +100,10 @@ PLATFORMS
 DEPENDENCIES
   activemodel
   activesupport
+  bcrypt_pbkdf
   concurrent-ruby
   dotenv
+  ed25519
   fakefs
   flight_auth!
   flight_configuration!


### PR DESCRIPTION
It would seem that changes to OpenSSH on EL8+ store keys by default in RFC4716 format (`-----BEGIN OPENSSH PRIVATE KEY-----`) instead of PEM format (`-----BEGIN RSA PRIVATE KEY-----`). The latter requires ed25519 to be available. This PR adds that gem.
